### PR TITLE
Update ODBC driver from version 17 to 18 for SCCM compatibility

### DIFF
--- a/sql-reporting-server/conf.d/sqlserver.d/conf.yaml
+++ b/sql-reporting-server/conf.d/sqlserver.d/conf.yaml
@@ -9,7 +9,7 @@ instances:
     username: datadog_monitoring_user
     password: YOUR_SQL_MONITORING_PASSWORD
     connector: odbc
-    driver: ODBC Driver 17 for SQL Server
+    driver: ODBC Driver 18 for SQL Server
     tags:
       - role:sccm-sql-reporting-server
       - database:reportserver

--- a/sql-reporting-server/conf.d/sqlserver.d/conf.yaml.alt
+++ b/sql-reporting-server/conf.d/sqlserver.d/conf.yaml.alt
@@ -9,7 +9,7 @@ instances:
   - host: localhost,1433
     connection_string: "Trusted_Connection=yes"
     connector: odbc
-    driver: ODBC Driver 17 for SQL Server
+    driver: ODBC Driver 18 for SQL Server
     tags:
       - role:sccm-sql-reporting-server
       - database:reportserver

--- a/sql-server/conf.d/sqlserver.d/conf.yaml
+++ b/sql-server/conf.d/sqlserver.d/conf.yaml
@@ -9,7 +9,7 @@ instances:
     username: datadog_monitoring_user
     password: YOUR_SQL_MONITORING_PASSWORD
     connector: odbc
-    driver: ODBC Driver 17 for SQL Server
+    driver: ODBC Driver 18 for SQL Server
     tags:
       - role:sccm-sql-server
       - database:sccm

--- a/sql-server/conf.d/sqlserver.d/conf.yaml.alt
+++ b/sql-server/conf.d/sqlserver.d/conf.yaml.alt
@@ -9,7 +9,7 @@ instances:
   - host: localhost,1433
     connection_string: "Trusted_Connection=yes"
     connector: odbc
-    driver: ODBC Driver 17 for SQL Server
+    driver: ODBC Driver 18 for SQL Server
     tags:
       - role:sccm-sql-server
       - database:sccm


### PR DESCRIPTION
## Overview

This PR updates all SQL Server monitoring configurations to use **ODBC Driver 18 for SQL Server** instead of version 17, ensuring compatibility with modern SCCM environments.

## Problem

SCCM environments typically require SQL Server 2016 or later, and modern installations use ODBC Driver 18 for SQL Server. The previous configurations were using ODBC Driver 17, which may not be available in newer SCCM deployments.

## Changes Made

Updated ODBC driver version in all SQL Server configuration files:

### Files Updated
- `sql-server/conf.d/sqlserver.d/conf.yaml` - Standard SQL Server config
- `sql-server/conf.d/sqlserver.d/conf.yaml.alt` - Windows Authentication alternative
- `sql-reporting-server/conf.d/sqlserver.d/conf.yaml` - Standard SSRS config  
- `sql-reporting-server/conf.d/sqlserver.d/conf.yaml.alt` - Windows Auth SSRS alternative

### Change Details
```diff
- driver: ODBC Driver 17 for SQL Server
+ driver: ODBC Driver 18 for SQL Server
```

## SCCM Compatibility

According to Microsoft documentation, SCCM supports:
- SQL Server 2016 (minimum)
- SQL Server 2017
- SQL Server 2019  
- SQL Server 2022

These modern SQL Server versions typically come with or require ODBC Driver 18 for optimal compatibility and security.

## Impact

- **Positive**: Ensures compatibility with modern SCCM/SQL Server installations
- **Minimal Risk**: ODBC Driver 18 is backward compatible and widely available
- **No Functional Changes**: Only driver version updated, all other configuration remains the same

## Testing Considerations

After deployment, verify:
- [ ] ODBC Driver 18 for SQL Server is installed on target systems
- [ ] Datadog Agent can connect to SQL Server instances
- [ ] SQL Server metrics are being collected successfully
- [ ] No connection errors in Datadog Agent logs

## Rollback Plan

If issues arise, can easily revert by changing back to:
```yaml
driver: ODBC Driver 17 for SQL Server
```

## Notes

- This change affects both standard and Windows Authentication alternative configurations
- ODBC Driver 18 should be available on modern Windows Server installations
- For older environments that only have Driver 17, the configuration can be manually adjusted